### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/SuryaS0302/871be3ad-c13c-4c8d-bf46-c46eafddacaa/dc21d43f-03ae-4335-b3c2-1fca0dfa4980/_apis/work/boardbadge/2a4a7f73-6f10-4bc5-89a2-b32d35d4e631)](https://dev.azure.com/SuryaS0302/871be3ad-c13c-4c8d-bf46-c46eafddacaa/_boards/board/t/dc21d43f-03ae-4335-b3c2-1fca0dfa4980/Microsoft.RequirementCategory)
 # Final evaluation
 Wesbite for TWT-docs-as-code final evaluation


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/SuryaS0302/871be3ad-c13c-4c8d-bf46-c46eafddacaa/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.